### PR TITLE
nodejs-canary to v0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: nodejs-canary
   repository: http://jenkins-x-chartmuseum:8080
-  version: v0.0.3
+  version: v0.0.4
 - name: voting-app-result-nodejs-stateful
   repository: http://jenkins-x-chartmuseum:8080
   version: v0.0.11


### PR DESCRIPTION
Promote nodejs-canary to version v0.0.4